### PR TITLE
Add fuzzy Qud object ID matching to tile and wiki commands

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pre-commit = "*"
 pyyaml = "*"
 discord-py = "*"
 hagadias = {git = "https://github.com/TrashMonks/hagadias.git",ref = "master"}
+fuzzywuzzy = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c755721bd6dc4fb545d4241dbeb796683d0c5b796967c3342120fd78389e5973"
+            "sha256": "5d7423cf7a4302511b13240848fa9ce022a237f82f9ddf41516d54ef7d42facd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,10 +52,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.1.0"
+            "version": "==19.3.0"
         },
         "chardet": {
             "hashes": [
@@ -66,14 +66,22 @@
         },
         "discord-py": {
             "hashes": [
-                "sha256:4684733fa137cc7def18087ae935af615212e423e3dbbe3e84ef01d7ae8ed17d"
+                "sha256:2d5fec14b1c047b561336e969939e7f34564489851ec1a7edb8d303087127256"
             ],
             "index": "pypi",
-            "version": "==1.2.3"
+            "version": "==1.2.4"
+        },
+        "fuzzywuzzy": {
+            "hashes": [
+                "sha256:5ac7c0b3f4658d2743aa17da53a55598144edbc5bee3c6863840636e6926f254",
+                "sha256:6f49de47db00e1c71d40ad16da42284ac357936fa9b66bea1df63fed07122d62"
+            ],
+            "index": "pypi",
+            "version": "==0.17.0"
         },
         "hagadias": {
             "git": "https://github.com/TrashMonks/hagadias.git",
-            "ref": "505dcd0545860db727d7d72176729c90dfbcf9b3"
+            "ref": "fb4b06eaee1b5fa9e0c76feff37198f24c05fe14"
         },
         "idna": {
             "hashes": [
@@ -195,10 +203,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.1.0"
+            "version": "==19.3.0"
         },
         "cfgv": {
             "hashes": [
@@ -224,11 +232,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "identify": {
             "hashes": [
@@ -281,11 +289,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f",
-                "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"
+                "sha256:9f152687127ec90642a2cc3e4d9e1e6240c4eb153615cb02aa1ad41d331cbb6e",
+                "sha256:c2e4810d2d3102d354947907514a78c5d30424d299dc0fe48f5aa049826e9b50"
             ],
             "index": "pypi",
-            "version": "==1.18.3"
+            "version": "==1.20.0"
         },
         "py": {
             "hashes": [
@@ -310,18 +318,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
-                "sha256:813b99704b22c7d377bbd756ebe56c35252bb710937b46f207100e843440b3c2",
-                "sha256:cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31"
+                "sha256:8e256fe71eb74e14a4d20a5987bb5e1488f0511ee800680aaedc62b9358714e8",
+                "sha256:ff0090819f669aaa0284d0f4aad1a6d9d67a6efdc6dd4eb4ac56b704f890a0d6"
             ],
             "index": "pypi",
-            "version": "==5.1.3"
+            "version": "==5.2.4"
         },
         "pyyaml": {
             "hashes": [
@@ -344,10 +352,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "toml": {
             "hashes": [
@@ -358,10 +366,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:680af46846662bb38c5504b78bad9ed9e4f3ba2d54f54ba42494fdf94337fe30",
-                "sha256:f78d81b62d3147396ac33fc9d77579ddc42cc2a98dd9ea38886f616b33bc7fb2"
+                "sha256:11cb4608930d5fd3afb545ecf8db83fa50e1f96fc4fca80c94b07d2c83146589",
+                "sha256:d257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136"
             ],
-            "version": "==16.7.5"
+            "version": "==16.7.7"
         },
         "wcwidth": {
             "hashes": [

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -41,6 +41,7 @@ class Tiles(Cog):
                 msg = "Sorry, that specific object wasn't found, and it's too short to search."
                 return await ctx.send(msg)
         if obj is None:
+            # there was no exact match, and the query wasn't too short, so offer an alternative
             loop = asyncio.get_running_loop()
             # doing a fuzzy match on the qindex keys can take about 2 seconds, so
             # run in an executor so we can keep processing other commands in the meantime
@@ -49,7 +50,7 @@ class Tiles(Cog):
                                                      process.extractOne,
                                                      query,
                                                      list(qindex))
-            msg = f"Sorry, nothing matching that object was found. The closest object ID is" \
+            msg = "Sorry, nothing matching that object was found. The closest object ID is" \
                   f" `{nearest[0]}`."
             return await ctx.send(msg)
         if obj.tile is not None:

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -40,7 +40,6 @@ class Tiles(Cog):
             if len(query) < 3:
                 msg = "Sorry, that specific object wasn't found, and it's too short to search."
                 return await ctx.send(msg)
-        if obj is None:
             # there was no exact match, and the query wasn't too short, so offer an alternative
             loop = asyncio.get_running_loop()
             # doing a fuzzy match on the qindex keys can take about 2 seconds, so


### PR DESCRIPTION
This will add fuzzy object matching to the `?tile` command, like the ingame `wish` command. It also rewrites the `?wiki` search command to return close page title matches instead of just exact matches.