### PR TITLE
Animate tiles

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -153,7 +153,7 @@
         },
         "hagadias": {
             "git": "https://github.com/TrashMonks/hagadias.git",
-            "ref": "73915cd4ed7aea909262fa40891a6895a34bce29"
+            "ref": "58c48a81562cc1f5eee352fa20420ef946ce3cd8"
         },
         "idna": {
             "hashes": [

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -95,7 +95,8 @@ class Tiles(Cog):
 class TilesHelper:
 
     @staticmethod
-    async def process_tile_request(ctx: Context, *args, smalltile=False, animated=False, hologram=False):
+    async def process_tile_request(ctx: Context, *args, smalltile=False,
+                                   animated=False, hologram=False):
         log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
         query = ' '.join(args)
         if 'recolor' in query:
@@ -189,12 +190,14 @@ class TilesHelper:
 
     @staticmethod
     def get_bytesio_for_object(qud_object, qud_tile: QudTile, hologram=False):
-        """Provided a QudObject and a QudTile, creates a GIF and retrieves the associated BytesIO directly.
+        """Provided a QudObject and a QudTile, creates a GIF and retrieves the associated BytesIO
+        directly.
 
         Args:
             qud_object: The QudObject for which to create a GIF
             qud_tile: The tile variant to use for GIF creation
-            hologram: If True, create a holographic version of this tile instead of using it's default animation
+            hologram: If True, create a holographic version of this tile instead of using its
+                      default animation
         """
         animator = TileAnimator(qud_object, qud_tile)
         if hologram:

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -60,11 +60,19 @@ class Tiles(Cog):
         if obj.tile is not None:
             tile = obj.tile
             gif = None
-            if hologram or animated:
+            msg = ''
+            if hologram:
                 animator = TileAnimator(obj, tile)
-                if hologram:
-                    animator.apply_hologram_material_random()
+                animator.apply_hologram_material_random()
                 gif = animator.gif
+                msg += 'Hologram of '
+            elif animated:
+                if TileAnimator(obj).has_gif:
+                    animator = TileAnimator(obj, tile)
+                    gif = animator.gif
+                    msg += 'Animated '
+                else:
+                    msg += f"Sorry, `{obj.name}` does not have an animated tile.\n"
             elif recolor != '':
                 if recolor == 'random':
                     def random_color():
@@ -90,7 +98,7 @@ class Tiles(Cog):
             else:
                 data = tile.get_big_bytesio()
             data.seek(0)
-            msg = f"`{obj.name}` (display name: '{obj.displayname}'):"
+            msg += f"`{obj.name}` (display name: '{obj.displayname}'):"
             if not smalltile and not gif and TileAnimator(obj).has_gif:
                 msg += f"\nThis tile can be animated (`?animate {obj.name}`)"
             ext = '.png' if gif is None else '.gif'

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -33,7 +33,7 @@ class Tiles(Cog):
 
         Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
         """
-        return await TilesHelper.process_tile_request(ctx, *args)
+        return await process_tile_request(ctx, *args)
 
     @command()
     async def smalltile(self, ctx: Context, *args):
@@ -49,7 +49,7 @@ class Tiles(Cog):
 
         Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
         """
-        return await TilesHelper.process_tile_request(ctx, *args, smalltile=True)
+        return await process_tile_request(ctx, *args, smalltile=True)
 
     @command()
     async def randomtile(self, ctx: Context, *args):
@@ -71,7 +71,7 @@ class Tiles(Cog):
         while obj.tile is None:
             name = random.choice(names)
             obj = qindex[name]
-        return await(TilesHelper.process_tile_request(ctx, name, *args))
+        return await(process_tile_request(ctx, name, *args))
 
     @command()
     async def hologram(self, ctx: Context, *args):
@@ -80,7 +80,7 @@ class Tiles(Cog):
         Supported command formats:
           ?hologram <object>
         """
-        return await TilesHelper.process_tile_request(ctx, *args, hologram=True)
+        return await process_tile_request(ctx, *args, hologram=True)
 
     @command()
     async def animate(self, ctx: Context, *args):
@@ -89,120 +89,117 @@ class Tiles(Cog):
         Supported command formats:
           ?animate <object>
         """
-        return await TilesHelper.process_tile_request(ctx, *args, animated=True)
+        return await process_tile_request(ctx, *args, animated=True)
 
 
-class TilesHelper:
-
-    @staticmethod
-    async def process_tile_request(ctx: Context, *args, smalltile=False,
-                                   animated=False, hologram=False):
-        log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
-        query = ' '.join(args)
-        if 'recolor' in query:
-            query, recolor = [q.strip() for q in query.split('recolor')]
-        else:
-            recolor = ''
-        # search for exact matches first
-        obj = None
-        for key, val in qindex.items():
-            if query.lower() == key.lower():
-                obj = val
-                break
-        if obj is None:
-            # no matching blueprint name
-            # but, is there a blueprint with a matching displayname?
-            for blueprint, qobject in qindex.items():
-                if qobject.displayname.lower() == query.lower():
-                    obj = qobject
-        if obj is None:
-            if len(query) < 3:
-                msg = "Sorry, that specific blueprint name wasn't found, and it's too" \
-                      " short to search."
-                return await ctx.send(msg)
-            # there was no exact match, and the query wasn't too short, so offer an alternative
+async def process_tile_request(ctx: Context, *args, smalltile=False,
+                               animated=False, hologram=False):
+    log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
+    query = ' '.join(args)
+    if 'recolor' in query:
+        query, recolor = [q.strip() for q in query.split('recolor')]
+    else:
+        recolor = ''
+    # search for exact matches first
+    obj = None
+    for key, val in qindex.items():
+        if query.lower() == key.lower():
+            obj = val
+            break
+    if obj is None:
+        # no matching blueprint name
+        # but, is there a blueprint with a matching displayname?
+        for blueprint, qobject in qindex.items():
+            if qobject.displayname.lower() == query.lower():
+                obj = qobject
+    if obj is None:
+        if len(query) < 3:
+            msg = "Sorry, that specific blueprint name wasn't found, and it's too" \
+                  " short to search."
+            return await ctx.send(msg)
+        # there was no exact match, and the query wasn't too short, so offer an alternative
+        loop = asyncio.get_running_loop()
+        # doing a fuzzy match on the qindex keys can take about 2 seconds, so
+        # run in an executor so we can keep processing other commands in the meantime
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            nearest = await loop.run_in_executor(pool,
+                                                 process.extractOne,
+                                                 query,
+                                                 list(qindex))
+        msg = "Sorry, nothing matching that name was found. The closest blueprint name is" \
+              f" `{nearest[0]}`."
+        await ctx.send(msg)
+        # send the tile for the nearest match
+        obj = qindex[nearest[0]]
+    if obj.tile is not None:
+        tile = obj.tile
+        gif_bytesio = None
+        msg = ''
+        if hologram:
             loop = asyncio.get_running_loop()
-            # doing a fuzzy match on the qindex keys can take about 2 seconds, so
-            # run in an executor so we can keep processing other commands in the meantime
             with concurrent.futures.ThreadPoolExecutor() as pool:
-                nearest = await loop.run_in_executor(pool,
-                                                     process.extractOne,
-                                                     query,
-                                                     list(qindex))
-            msg = "Sorry, nothing matching that name was found. The closest blueprint name is" \
-                  f" `{nearest[0]}`."
-            await ctx.send(msg)
-            # send the tile for the nearest match
-            obj = qindex[nearest[0]]
-        if obj.tile is not None:
-            tile = obj.tile
-            gif_bytesio = None
-            msg = ''
-            if hologram:
+                call = partial(get_bytesio_for_object, obj, tile, hologram=True)
+                gif_bytesio = await loop.run_in_executor(pool, call)
+            msg += 'Hologram of '
+        elif animated:
+            if TileAnimator(obj).has_gif:
                 loop = asyncio.get_running_loop()
                 with concurrent.futures.ThreadPoolExecutor() as pool:
-                    call = partial(TilesHelper.get_bytesio_for_object, obj, tile, hologram=True)
+                    call = partial(get_bytesio_for_object, obj, tile)
                     gif_bytesio = await loop.run_in_executor(pool, call)
-                msg += 'Hologram of '
-            elif animated:
-                if TileAnimator(obj).has_gif:
-                    loop = asyncio.get_running_loop()
-                    with concurrent.futures.ThreadPoolExecutor() as pool:
-                        call = partial(TilesHelper.get_bytesio_for_object, obj, tile)
-                        gif_bytesio = await loop.run_in_executor(pool, call)
-                    msg += 'Animated '
-                else:
-                    msg += f"Sorry, `{obj.name}` does not have an animated tile.\n"
-            elif recolor != '':
-                if recolor == 'random':
-                    def random_color():
-                        return random.choice(list(QUD_COLORS.keys()))
-
-                    colors = [random_color(), random_color()]
-                else:
-                    colors = recolor.split()
-                if len(colors) != 2 or not all(color in QUD_COLORS for color in colors):
-                    return await ctx.send('Syntax error with optional `recolor` argument.'
-                                          ' See `?help tile` for details.')
-                # user requested a recolor of the tile, use the old tile to make a new one
-                filename = obj.tile.filename
-                colorstring = obj.tile.colorstring
-                qudname = obj.tile.qudname
-                raw_transparent = obj.tile.raw_transparent
-                tile = QudTile(filename, colorstring, colors[0], colors[1], qudname,
-                               raw_transparent)
-            if gif_bytesio is not None:
-                data = gif_bytesio
-            elif smalltile:
-                data = tile.get_bytesio()
+                msg += 'Animated '
             else:
-                data = tile.get_big_bytesio()
-            data.seek(0)
-            msg += f"`{obj.name}` (display name: '{obj.displayname}'):"
-            if not smalltile and not gif_bytesio and TileAnimator(obj).has_gif:
-                msg += f"\nThis tile can be animated (`?animate {obj.name}`)"
-            ext = '.png' if gif_bytesio is None else '.gif'
-            return await ctx.send(msg, file=File(fp=data, filename=f'{obj.displayname}{ext}'))
+                msg += f"Sorry, `{obj.name}` does not have an animated tile.\n"
+        elif recolor != '':
+            if recolor == 'random':
+                def random_color():
+                    return random.choice(list(QUD_COLORS.keys()))
+
+                colors = [random_color(), random_color()]
+            else:
+                colors = recolor.split()
+            if len(colors) != 2 or not all(color in QUD_COLORS for color in colors):
+                return await ctx.send('Syntax error with optional `recolor` argument.'
+                                      ' See `?help tile` for details.')
+            # user requested a recolor of the tile, use the old tile to make a new one
+            filename = obj.tile.filename
+            colorstring = obj.tile.colorstring
+            qudname = obj.tile.qudname
+            raw_transparent = obj.tile.raw_transparent
+            tile = QudTile(filename, colorstring, colors[0], colors[1], qudname,
+                           raw_transparent)
+        if gif_bytesio is not None:
+            data = gif_bytesio
+        elif smalltile:
+            data = tile.get_bytesio()
         else:
-            msg = f"Sorry, the Qud blueprint `{obj.name}` (display name: '{obj.displayname}')" \
-                  " doesn't have a tile."
-            await ctx.send(msg)
+            data = tile.get_big_bytesio()
+        data.seek(0)
+        msg += f"`{obj.name}` (display name: '{obj.displayname}'):"
+        if not smalltile and not gif_bytesio and TileAnimator(obj).has_gif:
+            msg += f"\nThis tile can be animated (`?animate {obj.name}`)"
+        ext = '.png' if gif_bytesio is None else '.gif'
+        return await ctx.send(msg, file=File(fp=data, filename=f'{obj.displayname}{ext}'))
+    else:
+        msg = f"Sorry, the Qud blueprint `{obj.name}` (display name: '{obj.displayname}')" \
+              " doesn't have a tile."
+        await ctx.send(msg)
 
-    @staticmethod
-    def get_bytesio_for_object(qud_object, qud_tile: QudTile, hologram=False):
-        """Provided a QudObject and a QudTile, creates a GIF and retrieves the associated BytesIO
-        directly.
 
-        Args:
-            qud_object: The QudObject for which to create a GIF
-            qud_tile: The tile variant to use for GIF creation
-            hologram: If True, create a holographic version of this tile instead of using its
-                      default animation
-        """
-        animator = TileAnimator(qud_object, qud_tile)
-        if hologram:
-            animator.apply_hologram_material_random()
-        gif = animator.gif
-        if gif is not None:
-            return GifHelper.get_bytesio(gif)
-        return None
+def get_bytesio_for_object(qud_object, qud_tile: QudTile, hologram=False):
+    """Provided a QudObject and a QudTile, creates a GIF and retrieves the associated BytesIO
+    directly.
+
+    Args:
+        qud_object: The QudObject for which to create a GIF
+        qud_tile: The tile variant to use for GIF creation
+        hologram: If True, create a holographic version of this tile instead of using its
+                  default animation
+    """
+    animator = TileAnimator(qud_object, qud_tile)
+    if hologram:
+        animator.apply_hologram_material_random()
+    gif = animator.gif
+    if gif is not None:
+        return GifHelper.get_bytesio(gif)
+    return None

--- a/cogs/tiles.py
+++ b/cogs/tiles.py
@@ -3,6 +3,7 @@ import asyncio
 import concurrent.futures
 import logging
 import random
+from functools import partial
 
 from discord import File
 from discord.ext.commands import Cog, Context, command
@@ -18,8 +19,83 @@ log = logging.getLogger('bot.' + __name__)
 class Tiles(Cog):
     """Send game tiles to Discord."""
 
+    @command()
+    async def tile(self, ctx: Context, *args):
+        """Send the tile for the named Qud blueprint.
+
+        Supported command formats:
+          ?tile <object>
+          ?tile <object> recolor <color1> <color2>
+          ?tile <object> recolor random
+
+        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
+        recolor random => repaints the tile using random colors
+
+        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
+        """
+        return await TilesHelper.process_tile_request(ctx, *args)
+
+    @command()
+    async def smalltile(self, ctx: Context, *args):
+        """Send the small (game size) tile for the named Qud blueprint.
+
+        Supported command formats:
+          ?smalltile <object>
+          ?smalltile <object> recolor <color1> <color2>
+          ?smalltile <object> recolor random
+
+        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
+        recolor random => repaints the tile using random colors
+
+        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
+        """
+        return await TilesHelper.process_tile_request(ctx, *args, smalltile=True)
+
+    @command()
+    async def randomtile(self, ctx: Context, *args):
+        """Send a random game tile to the channel.
+
+        Supported command formats:
+          ?randomtile <object>
+          ?randomtile <object> recolor <color1> <color2>
+          ?randomtile <object> recolor random
+
+        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
+        recolor random => repaints the tile using random colors
+
+        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
+        """
+        names = list(qindex)
+        name = 'Object'
+        obj = qindex['Object']
+        while obj.tile is None:
+            name = random.choice(names)
+            obj = qindex[name]
+        return await(TilesHelper.process_tile_request(ctx, name, *args))
+
+    @command()
+    async def hologram(self, ctx: Context, *args):
+        """Sends a hologram of the named Qud object.
+
+        Supported command formats:
+          ?hologram <object>
+        """
+        return await TilesHelper.process_tile_request(ctx, *args, hologram=True)
+
+    @command()
+    async def animate(self, ctx: Context, *args):
+        """Sends an animated tile for the named Qud object, if it has one.
+
+        Supported command formats:
+          ?animate <object>
+        """
+        return await TilesHelper.process_tile_request(ctx, *args, animated=True)
+
+
+class TilesHelper:
+
     @staticmethod
-    async def _tile_internal(ctx: Context, *args, smalltile=False, animated=False, hologram=False):
+    async def process_tile_request(ctx: Context, *args, smalltile=False, animated=False, hologram=False):
         log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
         query = ' '.join(args)
         if 'recolor' in query:
@@ -59,17 +135,20 @@ class Tiles(Cog):
             obj = qindex[nearest[0]]
         if obj.tile is not None:
             tile = obj.tile
-            gif = None
+            gif_bytesio = None
             msg = ''
             if hologram:
-                animator = TileAnimator(obj, tile)
-                animator.apply_hologram_material_random()
-                gif = animator.gif
+                loop = asyncio.get_running_loop()
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    call = partial(TilesHelper.get_bytesio_for_object, obj, tile, hologram=True)
+                    gif_bytesio = await loop.run_in_executor(pool, call)
                 msg += 'Hologram of '
             elif animated:
                 if TileAnimator(obj).has_gif:
-                    animator = TileAnimator(obj, tile)
-                    gif = animator.gif
+                    loop = asyncio.get_running_loop()
+                    with concurrent.futures.ThreadPoolExecutor() as pool:
+                        call = partial(TilesHelper.get_bytesio_for_object, obj, tile)
+                        gif_bytesio = await loop.run_in_executor(pool, call)
                     msg += 'Animated '
                 else:
                     msg += f"Sorry, `{obj.name}` does not have an animated tile.\n"
@@ -91,91 +170,36 @@ class Tiles(Cog):
                 raw_transparent = obj.tile.raw_transparent
                 tile = QudTile(filename, colorstring, colors[0], colors[1], qudname,
                                raw_transparent)
-            if gif is not None:
-                data = GifHelper.get_bytesio(gif)
+            if gif_bytesio is not None:
+                data = gif_bytesio
             elif smalltile:
                 data = tile.get_bytesio()
             else:
                 data = tile.get_big_bytesio()
             data.seek(0)
             msg += f"`{obj.name}` (display name: '{obj.displayname}'):"
-            if not smalltile and not gif and TileAnimator(obj).has_gif:
+            if not smalltile and not gif_bytesio and TileAnimator(obj).has_gif:
                 msg += f"\nThis tile can be animated (`?animate {obj.name}`)"
-            ext = '.png' if gif is None else '.gif'
+            ext = '.png' if gif_bytesio is None else '.gif'
             return await ctx.send(msg, file=File(fp=data, filename=f'{obj.displayname}{ext}'))
         else:
             msg = f"Sorry, the Qud blueprint `{obj.name}` (display name: '{obj.displayname}')" \
                   " doesn't have a tile."
             await ctx.send(msg)
 
-    @command()
-    async def tile(self, ctx: Context, *args):
-        """Send the tile for the named Qud blueprint.
+    @staticmethod
+    def get_bytesio_for_object(qud_object, qud_tile: QudTile, hologram=False):
+        """Provided a QudObject and a QudTile, creates a GIF and retrieves the associated BytesIO directly.
 
-        Supported command formats:
-          ?tile <object>
-          ?tile <object> recolor <color1> <color2>
-          ?tile <object> recolor random
-
-        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
-        recolor random => repaints the tile using random colors
-
-        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
+        Args:
+            qud_object: The QudObject for which to create a GIF
+            qud_tile: The tile variant to use for GIF creation
+            hologram: If True, create a holographic version of this tile instead of using it's default animation
         """
-        return await Tiles._tile_internal(ctx, *args)
-
-    @command()
-    async def smalltile(self, ctx: Context, *args):
-        """Send the small (game size) tile for the named Qud blueprint.
-
-        Supported command formats:
-          ?smalltile <object>
-          ?smalltile <object> recolor <color1> <color2>
-          ?smalltile <object> recolor random
-
-        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
-        recolor random => repaints the tile using random colors
-
-        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
-        """
-        return await Tiles._tile_internal(ctx, *args, smalltile=True)
-
-    @command()
-    async def randomtile(self, ctx: Context, *args):
-        """Send a random game tile to the channel.
-
-        Supported command formats:
-          ?randomtile <object>
-          ?randomtile <object> recolor <color1> <color2>
-          ?randomtile <object> recolor random
-
-        recolor => repaints the tile using <color1> as TileColor and <color2> as DetailColor
-        recolor random => repaints the tile using random colors
-
-        Colors include: b, B, c, C, g, G, k, K, m, M, o, O, r, R, w, W, y, Y, transparent
-        """
-        names = list(qindex)
-        name = 'Object'
-        obj = qindex['Object']
-        while obj.tile is None:
-            name = random.choice(names)
-            obj = qindex[name]
-        return await(Tiles._tile_internal(ctx, name, *args))
-
-    @command()
-    async def hologram(self, ctx: Context, *args):
-        """Sends a hologram of the named Qud object.
-
-        Supported command formats:
-          ?hologram <object>
-        """
-        return await Tiles._tile_internal(ctx, *args, hologram=True)
-
-    @command()
-    async def animate(self, ctx: Context, *args):
-        """Sends an animated tile for the named Qud object, if it has one.
-
-        Supported command formats:
-          ?animate <object>
-        """
-        return await Tiles._tile_internal(ctx, *args, animated=True)
+        animator = TileAnimator(qud_object, qud_tile)
+        if hologram:
+            animator.apply_hologram_material_random()
+        gif = animator.gif
+        if gif is not None:
+            return GifHelper.get_bytesio(gif)
+        return None


### PR DESCRIPTION
- Adds the `?hologram <object>` and `?animate <object>` commands.
- Refactors `Tiles` to move the logic out of a command and into an internal/static method
  - This was to avoid showing a bunch of weird parameters in the `?help tile` docs.
- Improves/expands help text of all `Tiles` cog commands.
- When using the `?tile` command on a tile that can be animated, cryptogull will tell you it has an animated variant.