### PR TITLE
Update Crypto for build codes

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -153,7 +153,7 @@
         },
         "hagadias": {
             "git": "https://github.com/TrashMonks/hagadias.git",
-            "ref": "58c48a81562cc1f5eee352fa20420ef946ce3cd8"
+            "ref": "1921106108e5c086dd82f4705e18b50645485546"
         },
         "idna": {
             "hashes": [

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -27,8 +27,6 @@ class Decode(Cog):
             return  # only do interpretations in DMs or configured channels
         if message.author.id in self.config['ignore'] or message.author == self.bot.user:
             return  # ignore ignored users and bots
-        if message.content[1:8].lower() == 'upgrade':
-            return  # don't try to interpret the code in an upgrade command
         match = valid_charcode.search(message.content)
         if not match:
             return  # no code found
@@ -42,19 +40,3 @@ class Decode(Cog):
             await message.channel.send(response)
         except:  # noqa E722
             log.exception(f"Exception while decoding and sending character code {code}.")
-
-    @command()
-    async def upgrade(self, ctx: Context, code=None):
-        """Upgrades a build code from pre-2.0.200.0 to post-2.0.200.0.
-
-        Takes the old (pre-2020 'beta' branch) build code and gives the new one."""
-        log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
-        if code is None:
-            return await ctx.send_help(ctx.command)
-        match = valid_charcode.search(code)
-        if not match:
-            return await ctx.send(f"Sorry, but `{code}` doesn't seem to contain a"
-                                  f" valid character build code.")
-        code = match[0].strip()
-        char = Character.from_charcode(code)
-        return await ctx.send(char.upgrade())

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from discord.channel import DMChannel
-from discord.ext.commands import Bot, Cog, Context, command
+from discord.ext.commands import Bot, Cog
 from discord.message import Message
 
 from helpers.qud_decode import Character

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -37,6 +37,9 @@ class Decode(Cog):
             char = Character.from_charcode(code)
             sheet = char.make_sheet()
             response = f"```less\nCode:      {code}\n" + sheet + "\n```"
+            if len(response) > 2000:
+                response = "The character sheet for that build code is too large to fit into" \
+                           " a discord message."
             await message.channel.send(response)
         except:  # noqa E722
             log.exception(f"Exception while decoding and sending character code {code}.")

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -10,7 +10,7 @@ from shared import config
 
 log = logging.getLogger('bot.' + __name__)
 
-valid_charcode = re.compile(r"(?:^|\s)[AB][A-L][A-Z]{6}(?:[0-9A-Z][0-9A-Z])*")
+valid_charcode = re.compile(r"(?:^|\s)[AB][A-L][A-Z]{6}(?:[0-9A-Z][0-9A-Z](?:#\d)?)*")
 
 
 class Decode(Cog):
@@ -39,22 +39,13 @@ class Decode(Cog):
             char = Character.from_charcode(code)
             sheet = char.make_sheet()
             response = f"```less\nCode:      {code}\n" + sheet + "\n```"
-            if char.origin == 'post200':
-                response += 'Game version: >= 2.0.200'
-            elif char.origin == 'pre200':
-                response += 'Game version: < 2.0.200\n'
-                response += 'This code is from a version of the game lower than 2.0.200. '
-                response += 'To play that character on higher versions, you need to use '
-                response += char.upgrade() + ' instead.'
-            else:
-                response += 'Game version: 🧐'
             await message.channel.send(response)
         except:  # noqa E722
             log.exception(f"Exception while decoding and sending character code {code}.")
 
     @command()
     async def upgrade(self, ctx: Context, code=None):
-        """Upgrade a character build code from pre-2.0.200.0 to post-2.0.200.0.
+        """Upgrades a build code from pre-2.0.200.0 to post-2.0.200.0.
 
         Takes the old (pre-2020 'beta' branch) build code and gives the new one."""
         log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -91,6 +91,8 @@ class Character:
                 if subtypecode in 'IJKL':
                     extensions.append(gamecodes['mod_codes']['16'][2])
             else:
+                if charcode[:2] not in gamecodes['mod_codes']:
+                    raise ValueError(f'Invalid mutation or cybernetics code: "{charcode[:2]}"')
                 extensions.append(gamecodes['mod_codes'][charcode[:2]])
                 if charcode[:2] in gamecodes['mod_bonuses']:
                     bonuses = list(map(add, bonuses, gamecodes['mod_bonuses'][charcode[:2]]))

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -13,10 +13,9 @@ gamecodes = gameroot.get_character_codes()
 class Character:
     """Represents a Caves of Qud player character.
 
-    Note regarding the transitional period from pre-2.0.200.0 character build codes:
-    All Characters are considered to be created with the new, post-2.0.200.0 build codes.
-    The upgrade command has been preserved to allow players to upgrade a pre-2.0.200.0 build
-    code to a modern format buildcode if desired.
+    Will not work for old format build codes, such as bbuild codes from pre-2.0.200.0 (which
+    handle stats differently) or some build codes from before the mutation overhaul (which may
+    contain deprecated mutations).
     """
     def __init__(self,
                  attrs: List[int],       # one integer per stat, in game order
@@ -107,13 +106,10 @@ class Character:
         char.extensions_codes = extensions_codes
         return char
 
-    def to_charcode(self, upgrade=False) -> str:
+    def to_charcode(self) -> str:
         """Return a character build code for the Character.
-        Assumes by default that all attributes are "correct", so if the Character was
-        created using a build code, assume it was post200 unless overridden.
-
-        Check origin then call if an 'auto upgrade' is desired.
-        Parameters: incode and outcode can be 'pre200' or 'post200'.
+        Assumes by default that all attributes are "correct". Cryptogull will accept more build
+        codes than are technically valid/supported in game.
         """
         code = ''
         if self.genotype == 'True Kin':
@@ -126,23 +122,10 @@ class Character:
         elif self.genotype == 'Mutated Human':
             class_codes_flip = {v: k for k, v in gamecodes['calling_codes'].items()}
         code += class_codes_flip[self.class_name]
-        # if we are temporarily assuming we were created using a pre-2.0.200.0 build code,
-        # create a temporary "true" version of our attributes with bonuses subtracted
-        if upgrade:
-            true_attrs = []
-            for attr, bonus in zip(self.attrs, self.bonuses):
-                true_attrs.append(attr - bonus)
-        else:
-            true_attrs = self.attrs
-        for attr in true_attrs:
+        for attr in self.attrs:
             code += chr(attr + 59)
         code += self.extensions_codes
         return code
-
-    def upgrade(self) -> str:
-        """Return an upgraded (post-2.0.200.0) character build code as if this character
-        were created with a pre-2.0.200.0 build code."""
-        return self.to_charcode(upgrade=True)
 
     def make_sheet(self) -> str:
         """Build a printable character sheet for the Character."""

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -24,13 +24,9 @@ class Character:
     """Represents a Caves of Qud player character.
 
     Note regarding the transitional period from pre-2.0.200.0 character build codes:
-    All Characters are considered to be created with the new, post-2.0.200.0 build codes,
-    but there is functionality (for now) to temporarily consider the Character as if its
-    build code was pre-2.0.200.0. This will go away eventually.
-    This functionality is:
-        self.upgrade
-        self.origin (a conditional)
-        self.make_sheet (a conditional)
+    All Characters are considered to be created with the new, post-2.0.200.0 build codes.
+    The upgrade command has been preserved to allow players to upgrade a pre-2.0.200.0 build
+    code to a modern format buildcode if desired.
     """
     def __init__(self,
                  attrs: List[int],       # one integer per stat, in game order
@@ -51,7 +47,6 @@ class Character:
         self.extname = extname
         self.genotype = genotype
         self.skills = skills
-        self._origin_cache = None
 
         self.extensions_codes = ""
 
@@ -85,16 +80,20 @@ class Character:
 
         # after 8th character, characters come in pairs to give mutations or implants (if any)
         extensions = []
+        previouscode = None
         if genotype == "True Kin":
             extname = "Implants:  "
         else:
             extname = "Mutations: "
         while len(charcode) > 0:
             if charcode[:2].startswith('#'):
-                # temporarily skip this section of beta codes, still being implemented
-                charcode = charcode[2:]
-                continue
-            if charcode[:2] == '16':  # the 16th implant changes depending on arcology of origin
+                # Hash plus number indicates a variant of the previous mutation code
+                if previouscode is None or previouscode not in gamecodes['mutation_variants']:
+                    raise ValueError("Unexpected variant code")
+                variant = gamecodes['mutation_variants'][previouscode][int(charcode[1])]
+                extensions.pop()
+                extensions.append(variant)
+            elif charcode[:2] == '16':  # the 16th implant changes depending on arcology of origin
                 if subtypecode in 'ABCD':
                     extensions.append(gamecodes['mod_codes']['16'][0])
                 if subtypecode in 'EFGH':
@@ -105,6 +104,7 @@ class Character:
                 extensions.append(gamecodes['mod_codes'][charcode[:2]])
                 if charcode[:2] in gamecodes['mod_bonuses']:
                     bonuses = list(map(add, bonuses, gamecodes['mod_bonuses'][charcode[:2]]))
+            previouscode = charcode[:2]
             charcode = charcode[2:]
 
         # skills are not in the build code, they're determined solely by class
@@ -166,12 +166,7 @@ class Character:
                 bonus_text = f'{bonus}'  # already has a minus sign
             else:
                 bonus_text = ''
-            # pre-2.0.200.0 build codes had class bonuses baked into the attributes, so
-            # subtract those back out on autodetected 'old' builds:
-            if self.origin == 'pre200':
-                attr_strings.append(f'{attr_text:14}{attr - bonus:2}{bonus_text}')
-            else:
-                attr_strings.append(f'{attr_text:14}{attr:2}{bonus_text}')
+            attr_strings.append(f'{attr_text:14}{attr:2}{bonus_text}')
         charsheet += f"""
 {attr_strings[0]:21}    {attr_strings[3]}
 {attr_strings[1]:21}    {attr_strings[4]}
@@ -179,43 +174,6 @@ class Character:
         charsheet += f"\n{self.extname}{', '.join(self.extensions)}"
         charsheet += f"\nSkills:    {', '.join(self.skills)}"
         return charsheet
-
-    @property
-    def origin(self) -> str:
-        """Return 'post200' if this character code adds up to a max point spend from
-        post-2.0.200.0 (the 'beta branch') of Caves of Qud, 'pre200' if it is from
-        before that, or 'unknown' if it is from neither (maybe altered)."""
-        if self._origin_cache is not None:
-            return self._origin_cache
-        mutant_points = 44
-        truekin_points = 38
-        points_spent = 0
-        base = 12 if self.genotype == "True Kin" else 10
-        origin = 'unknown'
-        # check if this adds up to a post-2.0.200.0 character
-        went_negative = False
-        for attr in self.attrs:
-            if attr < base:
-                went_negative = True
-            points_spent += point_spend(attr, base)
-        if (self.genotype == "Mutated Human" and points_spent == mutant_points)\
-                or (self.genotype == "True Kin" and points_spent == truekin_points)\
-                and not went_negative:
-            origin = 'post200'
-        # check if this adds up to a pre-2.0.200.0 character
-        points_spent = 0
-        went_negative = False
-        for attr, bonus in zip(self.attrs, self.bonuses):
-            attr -= bonus
-            if attr < base:
-                went_negative = True
-            points_spent += point_spend(attr, base)
-        if (self.genotype == "Mutated Human" and points_spent == mutant_points)\
-                or (self.genotype == "True Kin" and points_spent == truekin_points)\
-                and not went_negative:
-            origin = 'pre200'
-        self._origin_cache = origin
-        return origin
 
     def __str__(self):
         """Return a string representation of the Character."""

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -10,16 +10,6 @@ from shared import gameroot
 gamecodes = gameroot.get_character_codes()
 
 
-def point_spend(attr: int, base: int) -> int:
-    """Return the number of stat points required to raise a stat from base to given value."""
-    spent = 0
-    if attr > 18:
-        spent += (attr - 18) * 2
-        attr = 18
-    spent += attr - base
-    return spent
-
-
 class Character:
     """Represents a Caves of Qud player character.
 

--- a/helpers/qud_decode_test.py
+++ b/helpers/qud_decode_test.py
@@ -11,16 +11,17 @@ from helpers.qud_decode import Character
 build_codes = ('AAPMNNJL16',
                'BARFIGHTBABE',
                'BJQMMOEIBNBOBPBRDPED',
-               'BAIIMLLRB5CHDADCDDDX',
+               'BAIIMLLRB5CMDADCDDDX',
                'BCCGDEHEBKB2CDDB',
                'BAMMMMLLU5EB',
                'BINKMMKKBPBSB1B2CADP',
                )
 
-# Stress test with every mutation and implant:
-all_mods = 'BAEEEEEGAAABBABBBCB6BDBEBFBGBHBIBJBKBLBMBNBOBPBQBRBSBTBUBVBWBXBYBZB1B2B3B4B5CACBC'\
-           'CCDCECFCGCHCICJCLDADBDCDDDEDFDGDHDIDJDKDLDMDNDODPDQDRDSDTDUDVDWDXDYDZD1EAEBECEDEE'\
-           'EFEG0001040506070809111213141516U1U2U3U4'
+# Stress test with every mutation and implant. Note that this results in a character sheet that
+# exceeds discord's character limit, so it won't actually work in Cryptogull itself.
+all_mods = 'BAEEEEEGAAABBACDBBBCBDBEBFBGBHBIBJBKBLBMBNBOBPBQBRBSBTBUBVBWBXBYBZB1B2B3B4B5CACB'\
+           'CFCCB6CECGCICNCJCLCMDADBDCDDDEDFDGDHDIDJDKDLDMDNDODPDQDRDSDTDUDVDWDXDYDZD1EAEBEI'\
+           'ECEDEHEF0001040506070809111213141516U1U2U3U4'
 
 
 def test_qud_decode():


### PR DESCRIPTION
- Adds support for mutation variant codes (dependent on latest hagadias update)
  - Also updated mutation bonus values in hagadias based on the latest stuff
- Removes the old logic for determining 'pre200' and 'post200' build codes
  - No longer tells you if your code is >=200 or <200 in the output
- The `upgrade` command has been preserved just in case folks have old build codes laying around
  - I admit I didn't really test this, because I don't have any old codes. But it does do _something_ to codes you feed it, so I assume it still works?