### PR TITLE
Build code embeds

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -153,7 +153,7 @@
         },
         "hagadias": {
             "git": "https://github.com/TrashMonks/hagadias.git",
-            "ref": "4eab923b5095671ff4dbaec70a57d504b6adee21"
+            "ref": "1d3bb53c85b09fed6b09c89328a609377b1e09a8"
         },
         "idna": {
             "hashes": [

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -44,9 +44,10 @@ class Decode(Cog):
             else:
                 thumbnail = char.tile.get_big_bytesio()
                 thumbnail.seek(0)
-                embedfile = File(fp=thumbnail, filename=f'{char.class_name}.png')
+                img_filename = ''.join(ch for ch in char.class_name if ch.isalnum()) + '.png'
+                embedfile = File(fp=thumbnail, filename=f'{img_filename}')
                 embed = Embed(description=response, color=0x2AA18B)
-                embed.set_thumbnail(url=f'attachment://{char.class_name}.png')
+                embed.set_thumbnail(url=f'attachment://{img_filename}')
                 await message.channel.send(embed=embed, file=embedfile)
         except:  # noqa E722
             log.exception(f"Exception while decoding and sending character code {code}.")

--- a/cogs/decode.py
+++ b/cogs/decode.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from discord import File, Embed
 from discord.channel import DMChannel
 from discord.ext.commands import Bot, Cog
 from discord.message import Message
@@ -36,10 +37,16 @@ class Decode(Cog):
         try:
             char = Character.from_charcode(code)
             sheet = char.make_sheet()
-            response = f"```less\nCode:      {code}\n" + sheet + "\n```"
-            if len(response) > 2000:
-                response = "The character sheet for that build code is too large to fit into" \
-                           " a discord message."
-            await message.channel.send(response)
+            response = f'```less\n{sheet}\n```\n**Build code:** {code}'
+            if len(response) > 2048:
+                await message.channel.send('The character sheet for that build code'
+                                           ' is too large to fit into a Discord message.')
+            else:
+                thumbnail = char.tile.get_big_bytesio()
+                thumbnail.seek(0)
+                embedfile = File(fp=thumbnail, filename=f'{char.class_name}.png')
+                embed = Embed(description=response, color=0x2AA18B)
+                embed.set_thumbnail(url=f'attachment://{char.class_name}.png')
+                await message.channel.send(embed=embed, file=embedfile)
         except:  # noqa E722
             log.exception(f"Exception while decoding and sending character code {code}.")

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -6,6 +6,8 @@ and for building a printable character sheet based on the attributes.
 from operator import add
 from typing import List
 
+from hagadias.qudtile import QudTile
+
 from shared import gameroot
 gamecodes = gameroot.get_character_codes()
 
@@ -25,7 +27,8 @@ class Character:
                  extensions: List[str],  # the list of mutations or implants as strings
                  extname: str,           # "mutations" or "implants"
                  genotype: str,          # "Mutated Human" or "True Kin"
-                 skills: List[str]       # the list of skills as strings
+                 skills: List[str],      # the list of skills as strings
+                 qud_tile: QudTile       # sprite for this calling or caste
                  ):
 
         self.attrs = attrs
@@ -36,6 +39,7 @@ class Character:
         self.extname = extname
         self.genotype = genotype
         self.skills = skills
+        self.tile = qud_tile
 
         self.extensions_codes = ""
 
@@ -101,8 +105,13 @@ class Character:
         # skills are not in the build code, they're determined solely by class
         skills = [skill for skill in gamecodes['class_skills'][class_name]]
 
+        tile = QudTile(filename=gamecodes['class_tiles'][class_name][0],
+                       colorstring='y', raw_tilecolor='y',
+                       raw_detailcolor=gamecodes['class_tiles'][class_name][1],
+                       qudname=class_name)
+
         char = Character(attrs, bonuses, class_name, class_called,
-                         extensions, extname, genotype, skills)
+                         extensions, extname, genotype, skills, tile)
         char.extensions_codes = extensions_codes
         return char
 

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -131,9 +131,10 @@ class Character:
         """Build a printable character sheet for the Character."""
         charsheet = f"""Genotype:  {self.genotype}
 {self.class_called:11}{self.class_name}"""
+        attr_widths = (11, 11, 11, 14, 14, 14)
         attributes = ('Strength:', 'Agility:', 'Toughness:', 'Intelligence:', 'Willpower:', 'Ego:')
         attr_strings = []
-        for attr_text, attr, bonus in zip(attributes, self.attrs, self.bonuses):
+        for width, attr_text, attr, bonus in zip(attr_widths, attributes, self.attrs, self.bonuses):
             # print a +/- in front of any existing bonus
             if bonus > 0:
                 bonus_text = f'+{bonus}'
@@ -141,11 +142,11 @@ class Character:
                 bonus_text = f'{bonus}'  # already has a minus sign
             else:
                 bonus_text = ''
-            attr_strings.append(f'{attr_text:14}{attr:2}{bonus_text}')
+            attr_strings.append(f'{attr_text:{width}}{attr:2}{bonus_text}')
         charsheet += f"""
-{attr_strings[0]:21}    {attr_strings[3]}
-{attr_strings[1]:21}    {attr_strings[4]}
-{attr_strings[2]:21}    {attr_strings[5]}"""
+{attr_strings[0]:18}{attr_strings[3]}
+{attr_strings[1]:18}{attr_strings[4]}
+{attr_strings[2]:18}{attr_strings[5]}"""
         charsheet += f"\n{self.extname}{', '.join(self.extensions)}"
         charsheet += f"\nSkills:    {', '.join(self.skills)}"
         return charsheet


### PR DESCRIPTION
Converts build code cog into an embed. Example:

![image](https://user-images.githubusercontent.com/3429497/107157184-546e2b00-6948-11eb-886a-5a8b7dd6f409.png)

## Related/Additional Changes
- Load subtype sprites in hagadias (https://github.com/TrashMonks/hagadias/commit/1d3bb53c85b09fed6b09c89328a609377b1e09a8)
- Reduce character sheet stat block width for better mobile-friendliness