### PR TITLE
Embeded wikipage queries

### DIFF
--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -99,6 +99,7 @@ class Wiki(Cog):
                   'search': query,
                   'namespace': get_wiki_namespaces('Main,Category,Modding'),
                   'limit': self.title_limit if limit is None else limit,
+                  'profile': 'fuzzy',
                   'redirects': 'resolve',
                   'format': 'json'}
         async with http_session.get(url=self.url, params=params) as reply:

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -90,7 +90,7 @@ class Wiki(Cog):
             # use full embed for single wiki page result:
             page_info: WikiPageSummary = await get_wiki_page_summary(self.url, titles[0], True)
             if page_info.look_description:
-                reply += f'*{page_info.look_description}*'
+                reply += f'{page_info.look_description}\n'
             if page_info.wiki_description:
                 reply += ('\n' if len(reply) > 0 else '') + page_info.wiki_description
             embed = Embed(colour=Colour(0xc3c9b1), description=reply)

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -79,7 +79,6 @@ class Wiki(Cog):
         Args:
             sub_path: The wiki page name or sub-path, not including an initial forward slash.
         """
-        log.info(f'https://{self.config["site"]}/{sub_path.replace(" ", "_")}')
         return f'https://{self.config["site"]}/{sub_path.replace(" ", "_")}'
 
     async def wiki_helper(self, limit: Optional[int], ctx: Context, *args):

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -100,7 +100,6 @@ class Wiki(Cog):
                   'search': query,
                   'namespace': get_wiki_namespaces('Main,Category,Modding'),
                   'limit': self.title_limit if limit is None else limit,
-                  'profile': 'fuzzy',
                   'redirects': 'resolve',
                   'format': 'json'}
         async with http_session.get(url=self.url, params=params) as reply:

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -31,25 +31,44 @@ class Wiki(Cog):
 
     @command()
     async def wiki(self, ctx: Context, *args):
-        """Gets up to 10 matching wiki pages."""
+        """Gets up to 10 matching wiki pages.
+
+        Supported command formats:
+          ?wiki <search query>
+        """
         async with ctx.typing():
             await self.wiki_helper(None, ctx, *args)
 
     @command()
     async def wikipage(self, ctx: Context, *args):
-        """Gets a full summary and image for the closest wiki page match."""
+        """Gets a full summary and image for the closest wiki page match.
+
+        Supported command formats:
+          ?wikipage <title or search query>
+        """
         async with ctx.typing():
             await self.wiki_helper(1, ctx, *args)
 
     @command()
     async def wikirandom(self, ctx: Context, *args):
-        """Gets a random wiki page."""
+        """Gets a random wiki page.
+
+        Supported command formats:
+          ?wikirandom
+          ?wikirandom <namespace>
+
+        Supported namespaces include: main, modding, category, data, talk, file, template, module
+        """
         async with ctx.typing():
             await self.random_wikipage(ctx, *args)
 
     @command()
     async def wikisearch(self, ctx: Context, *args):
-        """Gets up to 5 matching wiki pages, with summaries if available."""
+        """Gets up to 5 matching wiki pages, with summaries if available.
+
+        Supported command formats:
+          ?wikisearch <search query>
+        """
         async with ctx.typing():
             await self.wikisearch_helper(ctx, *args)
 

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -74,7 +74,7 @@ class Wiki(Cog):
             if response['error']['code'] == 'internal_api_error_TypeError':
                 await ctx.send('Sorry, that query didn\'t find any article titles.'
                                ' Performing fulltext search:')
-                return await(self.wikisearch(ctx, *args))
+                return await(self.wikisearch_helper(ctx, *args))
             else:
                 try:
                     info = ''.join(response['error']['info'])
@@ -88,8 +88,7 @@ class Wiki(Cog):
         reply = ''
         if len(titles) == 1:
             # use full embed for single wiki page result:
-            async with ctx.typing():
-                page_info: WikiPageSummary = await get_wiki_page_summary(self.url, titles[0], True)
+            page_info: WikiPageSummary = await get_wiki_page_summary(self.url, titles[0], True)
             if page_info.look_description:
                 reply += f'*{page_info.look_description}*'
             if page_info.wiki_description:
@@ -107,19 +106,25 @@ class Wiki(Cog):
         else:
             reply = f'*No results found for "{query}"*'
             embed = Embed(colour=Colour(0xc3c9b1), description=reply)
-        await ctx.send(embed=embed)
+        return await ctx.send(embed=embed)
 
     @command()
     async def wiki(self, ctx: Context, *args):
-        return await self.wiki_helper(None, ctx, *args)
+        async with ctx.typing():
+            return await self.wiki_helper(None, ctx, *args)
 
     @command()
     async def wikipage(self, ctx: Context, *args):
-        return await self.wiki_helper(1, ctx, *args)
+        async with ctx.typing():
+            return await self.wiki_helper(1, ctx, *args)
 
     @command()
     async def wikisearch(self, ctx: Context, *args):
         """Search the text of articles on the official Caves of Qud wiki."""
+        async with ctx.typing():
+            return await self.wikisearch_helper(ctx, *args)
+
+    async def wikisearch_helper(self, ctx: Context, *args):
         log.info(f'({ctx.message.channel}) <{ctx.message.author}> {ctx.message.content}')
         srsearch = ' '.join(args)
         if srsearch == '' or str.isspace(srsearch):  # no search term specified, return basic help
@@ -156,4 +161,4 @@ class Wiki(Cog):
             reply += '\n'
         embed = Embed(colour=Colour(0xc3c9b1),
                       description=reply)
-        await ctx.send(embed=embed)
+        return await ctx.send(embed=embed)

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -75,6 +75,7 @@ class WikiPageSummary:
             desc_match = wiki_desc_pattern.search(template_content)
             if desc_match is not None:
                 self._look_description = '> ' + self.strip_templates(desc_match.group(1))
+                self._look_description = self._look_description.replace('\n', '\n> ')
             # try to grab the image from the QBE template (much more reliable than above)
             wiki_image_pattern = re.compile(API_WIKI_TEMPLATE_IMAGE_REGEX, re.MULTILINE)
             image_match = wiki_image_pattern.search(template_content)

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -94,7 +94,7 @@ class WikiPageSummary:
         self._wiki_image = next((im for im in response['parse']['images']
                                  if im not in IGNORED_WIKI_IMAGES), None)
         wiki_text = response['parse']['wikitext']['*']
-        if '{{tocright}}' in wiki_text:
+        if any(tocright in wiki_text for tocright in ['{{tocright}}', '{{Tocright}}']):
             # workaround when {{tocright}} is present - if we try to retrieve only the intro when
             # this is the case, we get nothing (because TOC counts as a heading before the intro
             self.intro_only = False

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -173,9 +173,10 @@ class WikiPageSummary:
         desc_match = re.search(desc_pattern, page_wikitext, re.MULTILINE | re.DOTALL)
         if desc_match is not None:
             look_desc: str = desc_match.group(1)
+            look_desc = look_desc.replace('*', '\\*')  # escape asterisks for Discord markdown
             look_desc = look_desc.replace('\\n', '\n')  # fix raw '\n' in some mutation descriptions
             look_desc = WikiPageSummary.strip_templates(look_desc)  # remove templates
-            for common_color_str in ['&C', '&y', '&W', '&w']:  # remove color prefixes
+            for common_color_str in ['&amp;C', '&C', '&y', '&W', '&w']:  # remove color prefixes
                 look_desc = look_desc.replace(common_color_str, '')
             look_desc_lines = [
                 f'> *{li.strip()}*' if len(li.strip()) > 0 else '> '

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -1,0 +1,239 @@
+import re
+from typing import Optional
+from urllib.request import pathname2url
+
+from shared import http_session
+
+WIKI_FAVICON = "https://static.wikia.nocookie.net/cavesofqud_gamepedia_en/images/2/26/Favicon.png"
+
+API_WIKI_TEMPLATE_REGEX = r"(.*?)(?:<!--.*?START QBE.*?-->)\n*(?:{{As Of Patch\|[0-9.]+}})?\n*({{(?:Item|Character|Food|Corpse).*^}})\n*(?:\[\[Category:.+?\]\])?\n?(?:<!--.*?END QBE.*?-->)(.*)"  # noqa E501
+API_WIKI_TEMPLATE_DESC_REGEX = r"^\| *desc *= *(.+?)\n(?:\||})"
+API_WIKI_TEMPLATE_IMAGE_REGEX = r"^\| *image *= *(.+)$(?:\n\| *overrideimages *= *.*?\{\{altimage *\| *([^\|]+\S) *\|)?"  # noqa E501
+
+
+class WikiPageSummary:
+    def __init__(self, api_url: str, page_name: str, intro_only: bool, max_len: int = 1200):
+        """Creates a new WikiPageSummary object. WikiPageSummary.load() should be called
+        immediatley after instantiating a new WikiPageSummary object.
+
+        Args:
+            api_url: The wiki API endpoint URL
+            page_name: The wiki page name for which we are retrieving a summary (ex: 'Glowfish')
+            intro_only: True to return only the content before the first section header on the page.
+            max_len: Maximum content excerpt length (capped at 1200 characters at most)
+        """
+        self.url: str = api_url
+        self.intro_only: bool = intro_only
+        self.max_len: int = max_len if 1200 >= max_len > 0 else 1200
+        self.wiki_pattern = re.compile(API_WIKI_TEMPLATE_REGEX, re.MULTILINE | re.DOTALL)
+        self.pagename: str = page_name
+        self.error: Optional[str] = None
+        self._look_description: Optional[str] = None
+        self._wiki_description: Optional[str] = None
+        self._wiki_image: Optional[str] = None
+        self._wiki_image_url: Optional[str] = None
+
+    async def load(self):
+        """Loads data into this WikiPageSummary. This method should be called after creating a new
+        WikiPageSummary instance, and before accessing any other properties or methods."""
+        if self.pagename is None or self.pagename == '':
+            self.error = {'code': 'pageunknown', 'info': 'No wiki page was specified.'}
+            return
+
+        # The 'parse' API pulls the wikitext/images/etc from the page. This allows us to get more
+        # info from our QBE template and also to determine which image(s) are on the page.
+        #
+        #   API docs: https://www.mediawiki.org/wiki/API:Parsing_wikitext
+        #   Qud wiki API sandbox: https://bit.ly/3cU9uKf
+        #
+        parse_params = {
+            'action': 'parse',
+            'format': 'json',
+            'page': self.pagename,
+            'redirects': 1,
+            'prop': 'images|wikitext',
+        }
+        async with http_session.get(url=self.url, params=parse_params) as reply:
+            response = await reply.json()
+        if 'error' in response:
+            self.error = response['error']  # error object includes 'code' and 'info' sub-elements
+            return
+        for img in response['parse']['images']:
+            # first grab the image from the full list of page images (less reliable - see below)
+            if 'Ambox' not in img:  # ignore Ambox images
+                self._wiki_image = img
+                break
+        wiki_text = response['parse']['wikitext']['*']
+        if '{{tocright}}' in wiki_text:
+            # workaround when {{tocright}} is present - if we try to retrieve only the intro when
+            # this is the case, we get nothing (because TOC counts as a heading before the intro
+            self.intro_only = False
+        template_match = self.wiki_pattern.match(wiki_text)
+        if template_match is not None:  # true if this is a QBE-templated page
+            template_content = template_match.group(2)
+            wiki_desc_pattern = re.compile(API_WIKI_TEMPLATE_DESC_REGEX, re.MULTILINE | re.DOTALL)
+            desc_match = wiki_desc_pattern.search(template_content)
+            if desc_match is not None:
+                self._look_description = '> ' + self.strip_templates(desc_match.group(1))
+            # try to grab the image from the QBE template (much more reliable than above)
+            wiki_image_pattern = re.compile(API_WIKI_TEMPLATE_IMAGE_REGEX, re.MULTILINE)
+            image_match = wiki_image_pattern.search(template_content)
+            if image_match is not None:
+                if image_match.group(2) is not None:
+                    self._wiki_image = image_match.group(2)
+                else:
+                    self._wiki_image = image_match.group(1)
+                # get the image name in the correct caps/format from the image collection, if we can
+                if len(response['parse']['images']) > 0:
+                    val = self._wiki_image.lower().replace(' ', '_')
+                    for page_image in response['parse']['images']:
+                        if page_image.lower() == val:
+                            self._wiki_image = page_image
+                            break
+
+        # We follow up our 'parse' API call with a 'query' call to obtain these additional details:
+        #
+        #   Image URL
+        #     AllImages API allows us to pull the image details, including direct URL to an image
+        #     API docs: https://www.mediawiki.org/wiki/API:Allimages
+        #
+        #   Human-readable text page summary
+        #     TextExtracts API allows us to get a human-readable text translation of the wikitext on
+        #     the page, without trying to parse it ourselves. This ignores templates, such as our
+        #     infobox template, and also ignores images, tables, and links. It will include headers
+        #     with our current configuration (ex: "\n\n== Tips ==\nSome tip text"), but can be
+        #     reconfigured to return only the intro text before the first section header if needed.
+        #     API docs: https://www.mediawiki.org/wiki/Extension:TextExtracts
+        #
+        #   Qud wiki API sandbox: https://bit.ly/3pZKs02
+        #
+        extract_params = {
+            'action': 'query',
+            'format': 'json',
+            # TextExtracts API params:
+            'prop': 'extracts',
+            'titles': self.pagename,
+            'exchars': self.max_len,
+            'exlimit': 1,
+            'explaintext': 1
+        }
+        if self.intro_only:
+            extract_params['exintro'] = 1
+        if self._wiki_image is not None:
+            # merge allimages params into query call
+            allimages_params = {
+                'list': 'allimages',
+                'aifrom': self._wiki_image,
+                'aito': self._wiki_image,
+            }
+            extract_params = {**extract_params, **allimages_params}
+        async with http_session.get(url=self.url, params=extract_params) as reply:
+            response = await reply.json()
+        if 'error' in response:
+            self.error = response['error']  # error object includes 'code' and 'info' sub-elements
+            return
+        elif '-1' in response['query']['pages']:  # alternate error indicator for TextExtracts API
+            self.error = {'code': 'notfound', 'info': 'No page matches the API query.'}
+            return
+        page_id = list(response['query']['pages'])[0]
+        extract_text = response['query']['pages'][page_id]['extract']
+        if extract_text is not None and extract_text != '' and extract_text != '...':
+            self._wiki_description = self.cleanup_extract_formatting(extract_text)
+        if 'allimages' in response['query'] and len(response['query']['allimages']) > 0:
+            uri = response['query']['allimages'][0]['url']
+            encoded_wiki_image_url = pathname2url(self._wiki_image)
+            # Trim excess from image path (ex: <imageurl>.png/revision/latest?cb=20201231000000)
+            if encoded_wiki_image_url in uri:
+                self._wiki_image_url = uri.split(encoded_wiki_image_url)[0] + encoded_wiki_image_url
+
+    @staticmethod
+    def strip_templates(text: str) -> str:
+        """Strip wiki {{templates}} from string, including nested templates."""
+        i = 0
+        ret = ''
+        template_level = 0
+        while i < len(text):
+            if text[i] == '{' and text[i + 1] == '{':
+                template_level += 1
+                i += 1
+            elif text[i] == '}' and text[i + 1] == '}':
+                if template_level > 0:
+                    template_level -= 1
+                i += 1
+            elif template_level == 0:
+                ret += text[i]
+            i += 1
+        return ret.strip()
+
+    @staticmethod
+    def cleanup_extract_formatting(text: str) -> str:
+        """Cleans up the format of the wiki text extract, making it suitable for a Discord embed.
+        Makes the following changes:
+          - If a "References" section exists, removes that section and all subsequent content.
+          - Reformats page headers (ex: ==Header Two==) to use Discord markdown (ex: **Title**).
+          - Standardizes newline spacing
+        """
+        if '=' in text:
+            # strip ==References== section and anything subsequent from end of extract, if present:
+            references_patt = r'\n*^ *=+ *References *(?:\.\.\.)? *=+.*'
+            text = re.sub(references_patt, '', text, flags=re.MULTILINE | re.DOTALL)
+
+            # convert all headers from wikitext to Discord markdown
+            patterns = [
+                r'^ *= *([^=\n]+\S) *= *$\n*',  # h1
+                r'^ *== *([^=\n]+\S) *== *$\n*',  # h2
+                r'^ *=== *([^=\n]+\S) *=== *$\n*',  # h3
+                r'^ *====+ *([^=\n]+\S) *====+ *$\n*'  # h4 or beyond
+            ]
+            replacements = [
+                r'__**\1**__\n',  # h1
+                r'**\1**\n',  # h2
+                r'__*\1*__\n',  # h3
+                r'*\1*\n'  # h4 or beyond
+            ]
+            for patt, repl in zip(patterns, replacements):
+                text = re.sub(patt, repl, text, flags=re.MULTILINE)
+
+        # when ascending heading levels (ex: h3 -> h2), add an extra linebreak between.
+        ascending_h_patts = [
+            r'^(\*[^\*\n]+\*)\n(__\*[^\*\n]+\*__)$',
+            r'^(__\*[^\*\n]+\*__)\n(\*\*[^\*\n]+\*\*)$',
+            r'^(\*\*[^\*\n]+\*\*)\n(__\*\*[^\*\n]+\*\*__)$'
+        ]
+        for patt in ascending_h_patts:
+            text = re.sub(patt, r'\1\n\n\2', text, flags=re.MULTILINE)
+
+        # clean up any excessive (3+) linebreaks on the page:
+        linebreaks_patt = r'\n *\n *(?:\n *)+'
+        text = re.sub(linebreaks_patt, '\n\n', text, flags=re.MULTILINE)
+        return text
+
+    @property
+    def look_description(self) -> Optional[str]:
+        if self.error is not None:
+            raise RuntimeError('Attempted to access unresolved property of WikiPageSummary after '
+                               'WikiPageSummary.load() encountered an API error.')
+        return self._look_description
+
+    @property
+    def wiki_description(self) -> Optional[str]:
+        if self.error is not None:
+            raise RuntimeError('Attempted to access unresolved property of WikiPageSummary after '
+                               'WikiPageSummary.load() encountered an API error.')
+        return self._wiki_description
+
+    @property
+    def wiki_image_url(self) -> Optional[str]:
+        if self.error is not None:
+            raise RuntimeError('Attempted to access unresolved property of WikiPageSummary after '
+                               'WikiPageSummary.load() encountered an API error.')
+        return self._wiki_image_url
+
+
+async def get_wiki_page_summary(api_url: str,
+                                page_name: str,
+                                intro_only: bool,
+                                max_len: int = 1200) -> WikiPageSummary:
+    wikipage_summary = WikiPageSummary(api_url, page_name, intro_only, max_len)
+    await wikipage_summary.load()
+    return wikipage_summary

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -203,7 +203,7 @@ class WikiPageSummary:
             img = img.strip()
             # find the correct caps/format from the page's image list, if we can
             if len(page_images) > 0:
-                val = img.lower().replace(' ', '_')
+                val = img.lower().replace('  ', ' ').replace(' ', '_')
                 for page_image in page_images:
                     if page_image.lower() == val:
                         img = page_image

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -74,8 +74,12 @@ class WikiPageSummary:
             wiki_desc_pattern = re.compile(API_WIKI_TEMPLATE_DESC_REGEX, re.MULTILINE | re.DOTALL)
             desc_match = wiki_desc_pattern.search(template_content)
             if desc_match is not None:
-                self._look_description = '> ' + self.strip_templates(desc_match.group(1))
-                self._look_description = self._look_description.replace('\n', '\n> ')
+                look_desc = self.strip_templates(desc_match.group(1))
+                look_desc_lines = [
+                    f'> *{li}*' if len(li.strip()) > 0 else '> '
+                    for li in look_desc.splitlines()
+                ]
+                self._look_description = '\n'.join(look_desc_lines)
             # try to grab the image from the QBE template (much more reliable than above)
             wiki_image_pattern = re.compile(API_WIKI_TEMPLATE_IMAGE_REGEX, re.MULTILINE)
             image_match = wiki_image_pattern.search(template_content)


### PR DESCRIPTION
## Improved `?wikipage` Embed
Converts `?wikipage` into a full embed, including:
- Image from the wiki page
- Blockquote "Look" description pulled from the QBE template or any other wiki template with `desc` parameter
- Wiki summary text from the beginning of the page

Example:
![image](https://user-images.githubusercontent.com/3429497/107292704-e309a780-6a2f-11eb-87db-2955a6169710.png)

The embeds are currently restricted to show only the "intro" text from the page (everything before the first section header). However, it has been coded and fully tested to support longer extracts if desired.

## New command: `?wikirandom`
Formats:
- `?wikirandom`
- `?wikirandom <namespace>`

This command is a great way to test the overall embed and wiki page processing changes made in this PR, since it'll pull a wide variety of wiki pages in various formats. I have supported only a subset of namespaces - the ones that seemed most useful/relevant ([see `wiki_page.py`](https://github.com/TrashMonks/cryptogull/pull/37/files#diff-bec5c96d0947bae2dda59708543b8df66e1bbe9aa0b5cc89562829a9d8248e37R14-R23)).

![image](https://user-images.githubusercontent.com/3429497/107461446-9bfadf80-6b1f-11eb-943a-8692b5ea046a.png)

## A Note on Grammar Parsing
I ultimately decided to make an extra API call to resolve pronouns/grammar in 'look' descriptions from the wiki. This slightly reduces performance for character wiki pages that include grammar templates in the description, but seemed like an okay compromise for now. I've filed an issue in `hagadias` to track a potential improvement that could remove the need for this extra API call: https://github.com/TrashMonks/hagadias/issues/35

## Additional Notes
- Fixed `?wikisearch`. This logic could probably be expanded or applied to `?wiki` if we desire at a later time. Currently the main difference is that `?wikisearch` returns 5 results with short description snippets from the page, while `?wiki` returns up to 10 results with no description snippets.
- Significantly refactored a lot of stuff in Wiki cog
- Improved help text overall for Wiki cog - it now matches the format of help text in the Tile cog.