### PR TITLE
Wiki Cog Tweaks and Fixes

### DIFF
--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -49,7 +49,7 @@ class Wiki(Cog):
         async with ctx.typing():
             await self.wiki_helper(1, ctx, *args)
 
-    @command()
+    @command(aliases=['randomwiki'])
     async def wikirandom(self, ctx: Context, *args):
         """Gets a random wiki page.
 

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -212,5 +212,6 @@ class Wiki(Cog):
             return await ctx.send('Sorry, that random page query unexpectedly failed to return'
                                   ' any result.')
         page_name = response['query']['random'][0]['title']
+        log.info(f'Selected page "{page_name}" for ?wikirandom command')
         return await send_single_wiki_page(ctx, self.url, page_name, self.make_wiki_url(page_name),
                                            intro_only=True, max_len=1200)

--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -9,7 +9,7 @@ https://cavesofqud.gamepedia.com/api.php?action=help&modules=query%2Bsearch
 import logging
 from typing import Optional
 
-from discord import Colour, Embed, Message
+from discord import Message
 from discord.ext.commands import Bot, Cog, Context, command
 
 from helpers.wiki_page import send_single_wiki_page, send_wiki_page_list, send_wiki_error_message, \
@@ -162,16 +162,8 @@ class Wiki(Cog):
         results = response['query']['search']
         urls, snips = await pageids_to_urls_and_snippets(self.url,
                                                          [item['pageid'] for item in results])
-        reply = ''
-        for num, (match, url, snip) in enumerate(zip(results, urls, snips), start=1):
-            title = match['title']
-            reply += f'[{title}]({url})'
-            if snip is not None and snip != '' and snip != '...':
-                reply += f': {snip}'
-            reply += '\n'
-        embed = Embed(colour=Colour(0xc3c9b1),
-                      description=reply)
-        return await ctx.send(embed=embed)
+        return await send_wiki_page_list(ctx, titles=[match['title'] for match in results],
+                                         urls=urls, snippets=snips)
 
     async def random_wikipage(self, ctx: Context, *args) -> Message:
         """Sends a random wiki page to the channel.

--- a/helpers/qud_decode.py
+++ b/helpers/qud_decode.py
@@ -106,7 +106,8 @@ class Character:
         skills = [skill for skill in gamecodes['class_skills'][class_name]]
 
         tile = QudTile(filename=gamecodes['class_tiles'][class_name][0],
-                       colorstring='y', raw_tilecolor='y',
+                       colorstring=get_character_primary_color(extensions),
+                       raw_tilecolor=get_character_primary_color(extensions),
                        raw_detailcolor=gamecodes['class_tiles'][class_name][1],
                        qudname=class_name)
 
@@ -163,3 +164,12 @@ class Character:
     def __str__(self):
         """Return a string representation of the Character."""
         return f'Character {self.to_charcode()}'
+
+
+def get_character_primary_color(extensions: List[str]) -> str:
+    """Obtains a character's primary color.
+
+    Args:
+        extensions: List of character's mutations and cybernetics
+    """
+    return 'y' if 'Photosynthetic Skin' not in extensions else 'g'

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -9,7 +9,7 @@ from yarl import URL
 
 from shared import http_session
 
-WIKI_FAVICON = "https://static.wikia.nocookie.net/cavesofqud_gamepedia_en/images/2/26/Favicon.png"
+WIKI_FAVICON = 'https://static.wikia.nocookie.net/cavesofqud_gamepedia_en/images/0/05/Wiki-icon-used-by-CoQ-Discord-bot.png'  # noqa E501
 WIKI_SINGLE_PAGE_EMBED_COLOR = Colour(0xc3c9b1)
 WIKI_PAGE_LIST_EMBED_COLOR = Colour(0xc3c9b1)
 WIKI_PAGE_ERROR_EMBED_COLOR = Colour(0xc3c9b1)
@@ -386,7 +386,9 @@ async def send_single_wiki_page(ctx: Context, api_url: str, page_name: str, page
     embed = Embed(colour=WIKI_SINGLE_PAGE_EMBED_COLOR, description=reply)
     if page_info.wiki_image_url:
         embed.set_thumbnail(url=page_info.wiki_image_url)
-    embed.set_author(name=page_name, url=page_url, icon_url=WIKI_FAVICON)
+    embed.title = page_name
+    embed.url = page_url
+    embed.set_footer(text='Official Caves of Qud Wiki', icon_url=WIKI_FAVICON)
     return await ctx.send(embed=embed)
 
 
@@ -450,4 +452,3 @@ def encode_wiki_url_parens(wiki_url: str) -> str:
             url_parts[1] = url_parts[1].replace(paren, repl)
         wiki_url = url_parts[0] + '/' + url_parts[1]
     return wiki_url
-

--- a/helpers/wiki_page.py
+++ b/helpers/wiki_page.py
@@ -390,17 +390,22 @@ async def send_single_wiki_page(ctx: Context, api_url: str, page_name: str, page
     return await ctx.send(embed=embed)
 
 
-async def send_wiki_page_list(ctx: Context, titles: List[str], urls: List[str]) -> Message:
+async def send_wiki_page_list(ctx: Context, titles: List[str],
+                              urls: List[str], snippets: Optional[List[str]] = None) -> Message:
     """Sends a list of wiki pages to the Discord client as a simple embed.
 
     Args:
         ctx: Discord messaging context
         titles: The list of wiki page titles
         urls: The corresponding list of wiki page URLs
+        snippets: (Optional) short description snippets to include with each link
     """
     reply = ''
-    for title, url in zip(titles, urls):
-        reply += f'\n[{title}]({url})'
+    snippets = snippets if snippets is not None else [None] * len(titles)
+    for title, url, snip in zip(titles, urls, snippets):
+        reply += f'\n[{title}]({encode_wiki_url_parens(url)})'
+        if snip is not None and snip != '' and snip != '...':
+            reply += f': {snip}'
     embed = Embed(colour=WIKI_PAGE_LIST_EMBED_COLOR, description=reply)
     return await ctx.send(embed=embed)
 
@@ -433,3 +438,16 @@ async def pageids_to_urls_and_snippets(api_url: str, pageids: list) -> Tuple[lis
     summaries = [response['query']['pages'][str(pageid)]['extract'] for pageid in pageids]
     summaries = list(map(lambda s: s.replace('\n', ' '), summaries))
     return urls, summaries
+
+
+def encode_wiki_url_parens(wiki_url: str) -> str:
+    """Wiki pages that end in a parenthesis aren't rendered correctly in Discord mobile. This fixes
+    that issue by encoding parentheses and braces in the final part of the url path."""
+    paren_chars = {'(': '%28', ')': '%29', '[': '%5B', ']': '%5D'}
+    if any(paren in wiki_url for paren in paren_chars.keys()) and '/' in wiki_url:
+        url_parts = wiki_url.rsplit('/', 1)
+        for paren, repl in paren_chars.items():
+            url_parts[1] = url_parts[1].replace(paren, repl)
+        wiki_url = url_parts[0] + '/' + url_parts[1]
+    return wiki_url
+


### PR DESCRIPTION
Miscellaneous fixes and tweaks, mostly in the Wiki cog.

## Wiki Cog
- Fixes `?wikipage` not working for pages that end in a question mark (*?*)
- Fixes `?wikipage` links on iOS
![image](https://user-images.githubusercontent.com/3429497/107683446-2ef26180-6c67-11eb-83cc-57618ad30571.png)
- Fixes issue where parenthesis in page name broke links on mobile discord ![image](https://user-images.githubusercontent.com/3429497/107682992-ac69a200-6c66-11eb-8ae1-a478485cd085.png)
- Adds a log statement to `?wikirandom` to indicate the page crypto is attempting to retrieve, to simplify debug in case that command encounters a page-specific exception.
- Added alias command `?randomwiki`. Does the same thing as `?wikirandom`

## Decode
- Build code character sprites are now green if the build includes Photosynthetic Skin
