### PR TITLE
Brevity and Consistency Tweaks for `?wikipage`

### DIFF
--- a/cogs/wiki.py
+++ b/cogs/wiki.py
@@ -120,8 +120,8 @@ class Wiki(Cog):
         titles = response[1]
         urls = response[3]
         if len(titles) == 1:
-            return await send_single_wiki_page(ctx, self.url,
-                                               titles[0], urls[0], intro_only=True, max_len=1200)
+            return await send_single_wiki_page(ctx, self.url, titles[0], urls[0],
+                                               intro_only=True, max_len=620, max_paragraphs=2)
         elif len(titles) > 1:
             return await send_wiki_page_list(ctx, titles, urls)
         return await send_wiki_error_message(ctx, f'*No results found for "{query}"*')
@@ -206,4 +206,4 @@ class Wiki(Cog):
         page_name = response['query']['random'][0]['title']
         log.info(f'Selected page "{page_name}" for ?wikirandom command')
         return await send_single_wiki_page(ctx, self.url, page_name, self.make_wiki_url(page_name),
-                                           intro_only=True, max_len=1200)
+                                           intro_only=True, max_len=620, max_paragraphs=2)


### PR DESCRIPTION
- Reduces maximum total length of look description + wiki text from 1200 to 620 characters.
- Adds a 2 paragraph limit to wiki text, where a paragraph is defined as any distinct line with text on it.
- Fixes the issue that previously allowed wiki page headers to appear in the output when `{{tocright}}` was used on the page. Now, excerpts should never include section headers - only the intro is included.

## Example Before and After
### Before
![image](https://user-images.githubusercontent.com/3429497/108002113-2d50d280-6fb4-11eb-87a4-87a6ca6175fc.png)
### After
![image](https://user-images.githubusercontent.com/3429497/108002101-20cc7a00-6fb4-11eb-9c77-eaf1630ec9bd.png)
