### PR TITLE
Replace OAuth2 authentication with app password for Bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ server, in the `#code-of-conduct` channel.
 4. Skip directly to the "Bot" tab of the application you created. Set the icon
    and username here. These can be changed later. Click the button to reveal the
    bot token. Copy this token into the `Discord token:` field in `config.yml`.
-5. Turn on the "Server Members Intent" slider in the Bot tab.   
+5. Turn on the "Server Members Intent" slider in the Bot tab.
 6. If you don't have a private Discord server to test in, make one.
 7. Grab the 'Application ID' from the 'General Information' tab of the Discord
    application you created (different from your bot token!)
@@ -43,6 +43,11 @@ server, in the `#code-of-conduct` channel.
    **step 8**.
 10. Go to the URL and accept any prompts.
 11. Run the bot through Docker using the commands below.
+
+### Issue tracker configuration
+Cryptogull uses an app password to authenticate with the Bitbucket issue tracker.
+
+More info can be found at https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/.
 
 ## Example docker commands
 To build and run the bot:

--- a/config.example.yml
+++ b/config.example.yml
@@ -27,8 +27,8 @@ Bugs:
   fail reaction: ⚠️
   title max length: 80
   endpoint: https://api.bitbucket.org/2.0/repositories/test/test-issue-tracker/issues
-  oauth2 key: xxxxxxxxxxxxxxxxxx
-  oauth2 secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  bot username: xxxxxxxxxxxxxxxxxx
+  bot password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 Decode:
   channels: [            # Channels to listen for character build codes in:

--- a/poetry.lock
+++ b/poetry.lock
@@ -925,23 +925,6 @@ files = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.2.2"
-description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
-]
-
-[package.extras]
-rsa = ["cryptography (>=3.0.0)"]
-signals = ["blinker (>=1.4.0)"]
-signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
-
-[[package]]
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
@@ -1649,4 +1632,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "2856cbc72c21ba6e179d911e921094169df3e3b4f05b324fcfa9c9a1d5331846"
+content-hash = "8c9f8c7f9ed0f5f63059f4de226b17937757b4c315fcdf81487b6d2ac69e4529"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ python = "^3.13"
 "discord.py" = "1.7.3"
 PyYAML = "^6.0"
 fuzzywuzzy = "^0.18"
-oauthlib = "^3.2"
 asyncpraw = "^7.6"
 hagadias = {git = "https://github.com/TrashMonks/hagadias.git", branch = "main"}
 Levenshtein = "^0.26"


### PR DESCRIPTION
Until https://jira.atlassian.com/browse/BCLOUD-20342 gets solved, there does not appear to be a way to create an OAuth key for the issue tracker bot that has enough permissions to change the status of uploaded issues out of "submitted." An app password, on the other hand, currently works. Therefore—for the time being at least—we should use an app password instead.